### PR TITLE
BUG FIX: No levels attribute

### DIFF
--- a/templates/levels.php
+++ b/templates/levels.php
@@ -107,7 +107,7 @@ function pmpro_advanced_levels_shortcode($atts, $content=null, $code="")
 			}
 
 			// Reorder array
-			foreach ( $levels_order as $level_id) {
+			foreach ( $levels_order as $level_id ) {
 				foreach ( $pmpro_all_levels as $key => $level ) {
 					if ( $level_id == $level->id ) {
 						$pmpro_levels_filtered[] = $pmpro_all_levels[$key];

--- a/templates/levels.php
+++ b/templates/levels.php
@@ -98,11 +98,16 @@ function pmpro_advanced_levels_shortcode($atts, $content=null, $code="")
 				}
 			}
 		} else {
-			$pmpro_level_order = pmpro_getOption( 'level_order' );
-			$levels_order = explode( ',', $pmpro_level_order );
+			$pmpro_level_order = pmpro_getOption( 'level_order' ) ?: $pmpro_all_levels;
+
+			if ( ! is_array( $pmpro_level_order ) ) {
+				$levels_order = explode( ',', $pmpro_level_order );
+			} else {
+				$levels_order = array_keys( $pmpro_level_order );
+			}
 
 			// Reorder array
-			foreach ( $levels_order as $level_id ) {
+			foreach ( $levels_order as $level_id) {
 				foreach ( $pmpro_all_levels as $key => $level ) {
 					if ( $level_id == $level->id ) {
 						$pmpro_levels_filtered[] = $pmpro_all_levels[$key];


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the 'pmpro_level_order' isn't being set in PMPro core in some cases and now default to the list of levels.

I think this issue is happening in core more than this Add On but it accounts for the level_order option that may not be a string or blank so it's a good fail safe regardless.

Resolves: https://github.com/strangerstudios/pmpro-advanced-levels-shortcode/issues/46