### PR TITLE
Fixes PHP8 Error relating to allow_signups

### DIFF
--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -105,7 +105,7 @@ global $pmproal_link_arguments;
 						<?php
 							//if it's a one-time-payment level or recurring level that's expiring soon, offer a link to renew
 							$specific_level = pmpro_getSpecificMembershipLevelForUser($current_user->ID, $level->id);
-							if( pmpro_isLevelExpiringSoon( $specific_level ) && $specific_level->allow_signups )
+							if( pmpro_isLevelExpiringSoon( $specific_level ) && $level->allow_signups )
 							{
 							?>
 								<a class="<?php

--- a/templates/levels-div.php
+++ b/templates/levels-div.php
@@ -155,7 +155,7 @@ global $pmproal_link_arguments;
 					{
 						//if it's a one-time-payment level or recurring level that's expiring soon, offer a link to renew
 						$specific_level = pmpro_getSpecificMembershipLevelForUser($current_user->ID, $level->id);
-						if( pmpro_isLevelExpiringSoon( $specific_level ) && $specific_level->allow_signups )
+						if( pmpro_isLevelExpiringSoon( $specific_level ) && $level->allow_signups )
 						{
 							?>
 							<a class="<?php

--- a/templates/levels-table.php
+++ b/templates/levels-table.php
@@ -88,7 +88,7 @@ global $pmproal_link_arguments;
 			<?php
 				//if it's a one-time-payment level or recurring level that's expiring soon, offer a link to renew	
 				$specific_level = pmpro_getSpecificMembershipLevelForUser($current_user->ID, $level->id);										
-				if( pmpro_isLevelExpiringSoon( $specific_level) && $specific_level->allow_signups )
+				if( pmpro_isLevelExpiringSoon( $specific_level) && $level->allow_signups )
 				{
 				?>
 					<a class="<?php


### PR DESCRIPTION
Resolves #48 

The pmpro_getSpecificMembershipLevelForUser  function that is used in the $specific_level var no longer contains the allow_signups property, referencing the $level-> fixes this. 

Use the shortcode `[pmpro_advanced_levels levels="1,2,7" layout="compare_table" checkout_button="Sign Me Up!" ]` to test. 

If testing in PHP8, this pr (https://github.com/strangerstudios/pmpro-advanced-levels-shortcode/pull/49) should be merged in first as it contains a number of error fixes in the URLs of the Advanced Level buttons/hrefs
