### PR TITLE
Custom Level Cost Text will not replace text for FREE levels #41

### DIFF
--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -3,6 +3,8 @@
 	template for layout="compare_table"
 */
 global $pmproal_link_arguments;
+if (is_plugin_active('pmpro-level-cost-text') ) 
+	require_once WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'pmpro-level-cost-text' . DIRECTORY_SEPARATOR . 'pmpro-level-cost-text.php';
 ?>
 <table id="pmpro_levels" class="<?php if(!empty($template)) { echo "pmpro_advanced_levels-" . esc_attr( $template ) . " "; } ?>pmpro_advanced_levels-compare_table">
 	<thead>
@@ -28,23 +30,20 @@ global $pmproal_link_arguments;
 				{				  
 					?>
 					<th class="pmpro_level-price <?php if( pmpro_hasMembershipLevel( $level->id ) ) { echo 'pmpro_level-current '; } if(!empty($level) && $highlight == $level->id) { echo 'pmpro_level-highlight '; } ?>">
-						<?php
-							if(pmpro_isLevelFree($level))
-							{
-								if(!empty($expiration))
-								{
-									?>
-									<strong><?php esc_html_e('Free', 'pmpro-advanced-levels-shortcode'); ?></strong>
-									<?php
-								}
-								else
-								{	
-									?>
-									<strong><?php esc_html_e('Free', 'pmpro-advanced-levels-shortcode'); ?></strong>
-									<?php
-								}
-							}
-							elseif($price === 'full')
+						<?php if(pmpro_isLevelFree($level)) { ?>
+							<strong>
+								<?php 
+									// if pmpro-level-cost-text Add On is installed and activated and the level has a cost text, use that
+									if( function_exists( 'pmpro_getCustomLevelCostText' ) && pmpro_getCustomLevelCostText( $level->id ) != '') {
+										$text = pmpro_getCustomLevelCostText($level->id);
+									} else {
+										$text = __('Free', 'pmpro-advanced-levels-shortcode');
+									}
+									esc_html_e($text, 'pmpro-advanced-levels-shortcode');
+								?>
+							</strong>
+							<?php
+							} else if($price === 'full')
 								echo wp_kses( spanThePMProLevelCostText( pmpro_getLevelCost($level, true, false)), array( 'strong' => array(), 'span' => array() ) );
 							else
 								echo wp_kses( spanThePMProLevelCostText( pmpro_getLevelCost($level, false, true)), array( 'strong' => array(), 'span' => array() ) );
@@ -328,22 +327,16 @@ global $pmproal_link_arguments;
 					}
 					?>
 					<?php
-						if(pmpro_isLevelFree($level))
-						{
-							if(!empty($expiration))
-							{
-								?>
-								<strong><?php esc_html_e('Free.', 'pmpro-advanced-levels-shortcode'); ?></strong>
-								<?php
+						if(pmpro_isLevelFree($level)) {
+							// if pmpro-level-cost-text Add On is installed and activated and the level has a cost text, use that
+							if( function_exists( 'pmpro_getCustomLevelCostText' ) && pmpro_getCustomLevelCostText( $level->id ) != '') {
+								$text = pmpro_getCustomLevelCostText($level->id);
+							} else {
+								$text = __('Free', 'pmpro-advanced-levels-shortcode');
 							}
-							else
-							{	
-								?>
-								<strong><?php esc_html_e('Free', 'pmpro-advanced-levels-shortcode'); ?></strong>
-								<?php
-							}
-						}
-						elseif($price === 'full')
+							esc_html_e($text, 'pmpro-advanced-levels-shortcode');
+
+						} elseif($price === 'full')
 							echo wp_kses( pmpro_getLevelCost( $level, true, false ), array( 'strong' => array() ) );
 						else
 							echo wp_kses( pmpro_getLevelCost( $level, false, true ), array( 'strong' => array() ) );

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -3,8 +3,6 @@
 	template for layout="compare_table"
 */
 global $pmproal_link_arguments;
-if (is_plugin_active('pmpro-level-cost-text') ) 
-	require_once WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'pmpro-level-cost-text' . DIRECTORY_SEPARATOR . 'pmpro-level-cost-text.php';
 ?>
 <table id="pmpro_levels" class="<?php if(!empty($template)) { echo "pmpro_advanced_levels-" . esc_attr( $template ) . " "; } ?>pmpro_advanced_levels-compare_table">
 	<thead>
@@ -33,13 +31,13 @@ if (is_plugin_active('pmpro-level-cost-text') )
 						<?php if(pmpro_isLevelFree($level)) { ?>
 							<strong>
 								<?php 
-									// if pmpro-level-cost-text Add On is installed and activated and the level has a cost text, use that
-									if( function_exists( 'pmpro_getCustomLevelCostText' ) && pmpro_getCustomLevelCostText( $level->id ) != '') {
+									// if Custom Level Cost Text Add On is installed pull this information from the custom level cost text field.
+									if ( function_exists( 'pmpro_getCustomLevelCostText' ) && ! empty( pmpro_getCustomLevelCostText( $level->id ) ) ) {
 										$text = pmpro_getCustomLevelCostText($level->id);
 									} else {
-										$text = __('Free', 'pmpro-advanced-levels-shortcode');
+										$text = __( 'Free', 'pmpro-advanced-levels-shortcode' );
 									}
-									esc_html_e($text, 'pmpro-advanced-levels-shortcode');
+									esc_html_e( $text );
 								?>
 							</strong>
 							<?php
@@ -285,6 +283,8 @@ if (is_plugin_active('pmpro-level-cost-text') )
 		<?php } ?>					
 	</tfoot>
 </table>	
+
+
 <div id="pmpro_levels" class="
 <?php
 	if(!empty($template))
@@ -329,17 +329,19 @@ if (is_plugin_active('pmpro-level-cost-text') )
 					<?php
 						if(pmpro_isLevelFree($level)) {
 							// if pmpro-level-cost-text Add On is installed and activated and the level has a cost text, use that
-							if( function_exists( 'pmpro_getCustomLevelCostText' ) && pmpro_getCustomLevelCostText( $level->id ) != '') {
-								$text = pmpro_getCustomLevelCostText($level->id);
+							if( function_exists( 'pmpro_getCustomLevelCostText' ) && ! empty( pmpro_getCustomLevelCostText( $level->id ) ) ) {
+								$text = pmpro_getCustomLevelCostText( $level->id );
 							} else {
-								$text = __('Free', 'pmpro-advanced-levels-shortcode');
+								$text =  '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
 							}
-							esc_html_e($text, 'pmpro-advanced-levels-shortcode');
+							
+							echo wp_kses( $text , array( 'strong' => array() ) );
 
-						} elseif($price === 'full')
+						} elseif($price === 'full') {
 							echo wp_kses( pmpro_getLevelCost( $level, true, false ), array( 'strong' => array() ) );
-						else
+						} else {
 							echo wp_kses( pmpro_getLevelCost( $level, false, true ), array( 'strong' => array() ) );
+						}
 					
 					if($template === "foundation")
 					{

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -29,18 +29,16 @@ global $pmproal_link_arguments;
 					?>
 					<th class="pmpro_level-price <?php if( pmpro_hasMembershipLevel( $level->id ) ) { echo 'pmpro_level-current '; } if(!empty($level) && $highlight == $level->id) { echo 'pmpro_level-highlight '; } ?>">
 						<?php if(pmpro_isLevelFree($level)) { ?>
-							<strong>
-								<?php 
-									// if Custom Level Cost Text Add On is installed pull this information from the custom level cost text field.
-									if ( function_exists( 'pmpro_getCustomLevelCostText' ) && ! empty( pmpro_getCustomLevelCostText( $level->id ) ) ) {
-										$text = pmpro_getCustomLevelCostText($level->id);
-									} else {
-										$text = __( 'Free', 'pmpro-advanced-levels-shortcode' );
-									}
-									esc_html_e( $text );
-								?>
-							</strong>
-							<?php
+							<?php 
+								// if Custom Level Cost Text Add On is installed pull this information from the custom level cost text field.
+								if ( function_exists( 'pmpro_getCustomLevelCostText' ) && ! empty( pmpro_getCustomLevelCostText( $level->id ) ) ) {
+									$text = pmpro_getCustomLevelCostText($level->id);
+								} else {
+									$text = '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
+								}
+
+								echo wp_kses( $text, array( 'strong' => array() ) );
+								
 							} else if($price === 'full')
 								echo wp_kses( spanThePMProLevelCostText( pmpro_getLevelCost($level, true, false)), array( 'strong' => array(), 'span' => array() ) );
 							else

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -37,8 +37,8 @@ global $pmproal_link_arguments;
 									$text = '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
 								}
 
-								echo wp_kses( $text, array( 'strong' => array() ) );
-								
+								echo wp_kses( $text, pmproal_allowed_html() );
+
 							} else if($price === 'full')
 								echo wp_kses( spanThePMProLevelCostText( pmpro_getLevelCost($level, true, false)), array( 'strong' => array(), 'span' => array() ) );
 							else
@@ -333,12 +333,12 @@ global $pmproal_link_arguments;
 								$text =  '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
 							}
 							
-							echo wp_kses( $text , array( 'strong' => array() ) );
+							echo wp_kses( $text , pmproal_allowed_html() );
 
 						} elseif($price === 'full') {
-							echo wp_kses( pmpro_getLevelCost( $level, true, false ), array( 'strong' => array() ) );
+							echo wp_kses( pmpro_getLevelCost( $level, true, false ), pmproal_allowed_html() );
 						} else {
-							echo wp_kses( pmpro_getLevelCost( $level, false, true ), array( 'strong' => array() ) );
+							echo wp_kses( pmpro_getLevelCost( $level, false, true ), pmproal_allowed_html() );
 						}
 					
 					if($template === "foundation")

--- a/templates/levels-div.php
+++ b/templates/levels-div.php
@@ -87,25 +87,21 @@ global $pmproal_link_arguments;
 						?>
 						<li class="price">
 						<?php
-							if(pmpro_isLevelFree($level))
-							{
-								if(!empty($expiration))
-								{
-									?>
-									<strong><?php esc_html_e('Free.', 'pmpro-advanced-levels-shortcode'); ?></strong>
-									<?php
-								}
-								else
-								{	
-									?>
-									<strong><?php esc_html_e('Free', 'pmpro-advanced-levels-shortcode'); ?></strong>
-									<?php
-								}
+							if ( pmpro_isLevelFree( $level ) ) {
+							// if pmpro-level-cost-text Add On is installed and activated and the level has a cost text, use that
+							if( function_exists( 'pmpro_getCustomLevelCostText' ) && ! empty( pmpro_getCustomLevelCostText( $level->id ) ) ) {
+								$text = pmpro_getCustomLevelCostText( $level->id );
+							} else {
+								$text =  '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
 							}
-							elseif($price === 'full')
+							
+							echo wp_kses( $text , array( 'strong' => array() ) );
+
+							} elseif($price === 'full') {
 								echo wp_kses( spanThePMProLevelCostText( pmpro_getLevelCost($level, true, false)), array( 'strong' => array(), 'span' => array() ) );
-							else
+							} else {
 								echo wp_kses( spanThePMProLevelCostText( pmpro_getLevelCost($level, false, true)), array( 'strong' => array(), 'span' => array() ) );
+							}
 						?>
 						</li>
 					<?php
@@ -274,25 +270,21 @@ global $pmproal_link_arguments;
 						}
 						?>
 						<?php
-							if(pmpro_isLevelFree($level))
-							{
-								if(!empty($expiration))
-								{
-									?>
-									<strong><?php esc_html_e('Free.', 'pmpro-advanced-levels-shortcode'); ?></strong>
-									<?php
-								}
-								else
-								{	
-									?>
-									<strong><?php esc_html_e('Free', 'pmpro-advanced-levels-shortcode'); ?></strong>
-									<?php
-								}
+							if(pmpro_isLevelFree($level)) {
+							// if pmpro-level-cost-text Add On is installed and activated and the level has a cost text, use that
+							if( function_exists( 'pmpro_getCustomLevelCostText' ) && ! empty( pmpro_getCustomLevelCostText( $level->id ) ) ) {
+								$text = pmpro_getCustomLevelCostText( $level->id );
+							} else {
+								$text =  '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
 							}
-							elseif($price === 'full')
-								echo wp_kses( pmpro_getLevelCost( $level, true, false ), array( 'strong' => array() ) );
-							else
-								echo wp_kses( pmpro_getLevelCost( $level, false, true ), array( 'strong' => array() ) );
+							
+							echo wp_kses( $text , array( 'strong' => array() ) );
+
+						} elseif($price === 'full') {
+							echo wp_kses( pmpro_getLevelCost( $level, true, false ), array( 'strong' => array() ) );
+						} else {
+							echo wp_kses( pmpro_getLevelCost( $level, false, true ), array( 'strong' => array() ) );
+						}
 						
 						if($template === "foundation")
 						{

--- a/templates/levels-div.php
+++ b/templates/levels-div.php
@@ -95,7 +95,7 @@ global $pmproal_link_arguments;
 								$text =  '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
 							}
 							
-							echo wp_kses( $text , array( 'strong' => array() ) );
+							echo wp_kses( $text , pmproal_allowed_html() );
 
 							} elseif($price === 'full') {
 								echo wp_kses( spanThePMProLevelCostText( pmpro_getLevelCost($level, true, false)), array( 'strong' => array(), 'span' => array() ) );
@@ -278,12 +278,12 @@ global $pmproal_link_arguments;
 								$text =  '<strong>' . __( 'Free', 'pmpro-advanced-levels-shortcode' ) . '</strong>';
 							}
 							
-							echo wp_kses( $text , array( 'strong' => array() ) );
+							echo wp_kses( $text , pmproal_allowed_html() );
 
 						} elseif($price === 'full') {
-							echo wp_kses( pmpro_getLevelCost( $level, true, false ), array( 'strong' => array() ) );
+							echo wp_kses( pmpro_getLevelCost( $level, true, false ), pmproal_allowed_html() );
 						} else {
-							echo wp_kses( pmpro_getLevelCost( $level, false, true ), array( 'strong' => array() ) );
+							echo wp_kses( pmpro_getLevelCost( $level, false, true ), pmproal_allowed_html() );
 						}
 						
 						if($template === "foundation")


### PR DESCRIPTION
 * Check if custom level cost text Add On is enabled. In case of yes, get text from it and display that.

<img width="860" alt="image" src="https://github.com/strangerstudios/pmpro-advanced-levels-shortcode/assets/1678457/2ef89ec0-8a6a-434e-ad4a-05ddab9f3c99">
