### PR TITLE
Discount codes incorrectly applied when there's more than one shortco…

### DIFF
--- a/templates/levels.php
+++ b/templates/levels.php
@@ -114,14 +114,8 @@ function pmpro_advanced_levels_shortcode($atts, $content=null, $code="")
 		$pmpro_levels_filtered = apply_filters("pmpro_levels_array", $pmpro_levels_filtered);
 		$numeric_levels_array = array_values($pmpro_levels_filtered);
 
-		//Allows you to add ?discount_code=code to your URL
-		if( !empty( $_REQUEST['discount_code'] ) ){
-			$discount_code = sanitize_text_field( $_REQUEST['discount_code'] );
-		}
-
 		//update per discount code
-		if(!empty($discount_code) && !empty($pmpro_levels_filtered))
-		{			
+		if(!empty($discount_code) && !empty($pmpro_levels_filtered)) {
 			foreach($pmpro_levels_filtered as $level_id => $level)
 			{				
 				//check code for this level and update if applicable
@@ -135,6 +129,8 @@ function pmpro_advanced_levels_shortcode($atts, $content=null, $code="")
      
 				}
 			}		
+		} else {
+			unset( $pmproal_link_arguments['discount_code'] );
 		}
 	
 		do_action('pmproal_before_template_load' );


### PR DESCRIPTION
…de instance #52

 * Unset pmproal_link_arguments['discount_code'] if $discount_code is not present in the shortcode
 
 
<img width="737" alt="image" src="https://github.com/strangerstudios/pmpro-advanced-levels-shortcode/assets/1678457/de00503d-5246-4286-abef-46b9591082df">
<img width="748" alt="image" src="https://github.com/strangerstudios/pmpro-advanced-levels-shortcode/assets/1678457/737830d9-7423-4b2d-b461-ac966a228ab1">
