### PR TITLE
Remove unnecessary allow signups check.

### DIFF
--- a/pmpro-advanced-levels-shortcode.php
+++ b/pmpro-advanced-levels-shortcode.php
@@ -169,7 +169,7 @@ function pmproal_level_button( $level, $checkout_button, $renew_button, $account
 	} elseif( $level->current_level ) {
 		// Get specific level details for the user
 		$specific_level = pmpro_getSpecificMembershipLevelForUser( $current_user->ID, $level->id );
-		if ( pmpro_isLevelExpiringSoon( $specific_level ) && $specific_level->allow_signups ) {
+		if ( pmpro_isLevelExpiringSoon( $specific_level ) ) {
 			// Show renew button if the level is expiring soon and signups are allowed
 			$button_classes[] = 'pmpro_btn-select';
 			$button_classes[] = 'pmpro_btn-renew';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This was giving an error because we should have been checking $level->allow_signups.

BUT we don’t actually need this check at all, because we filter out any level that doesn't allow signups. So removing that check for this button.

### Changelog entry

* BUG FIX: Fixed error with the Renew button that shows when the current user's level is shown in the table.