### PR TITLE
Style updates for v3.1+ compat

### DIFF
--- a/css/pmpro-advanced-levels.css
+++ b/css/pmpro-advanced-levels.css
@@ -2,7 +2,7 @@
  * Root variables
  */
  :root {
-	--pmproal--border--color: #D1D1D1;
+	--pmproal--border--color: var(--pmpro--color--border--variation);
 	--pmproal--row--color-alt: #00000008;
 	--pmproal--spacing--large: 50px;
 	--pmproal--spacing--medium: 30px;
@@ -190,6 +190,10 @@
 	vertical-align: middle;
 }
 
+.pmpro_advanced_levels-compare_table th {
+	font-weight: normal;
+}
+
 .pmpro_advanced_levels-compare_table thead tr:first-child th:not(.pmpro_advanced_levels-compare_table thead tr:first-child th:first-child) {
 	border-top-width: 1px;
 	padding-top: var(--pmproal--spacing--medium);
@@ -220,6 +224,10 @@
 	border-top-width: 1px;
 }
 
+.pmpro_advanced_levels-compare_table tbody tr:nth-child(odd) td {
+	border-top-width: 1px;
+}
+
 .pmpro_advanced_levels-compare_table tbody tr td:first-child {
 	text-align: right;
 }
@@ -233,6 +241,9 @@
 	border-bottom-width: 1px;
 }
 
+.pmpro_advanced_levels-compare_table h2 {
+	font-weight: 700;
+}
 
 .pmpro_advanced_levels-compare_table .pmpro_level-description ul {
 	display: inline-block;

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -32,7 +32,7 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 				$count = 0;
 				foreach ( $pmpro_levels_filtered as $level ) { ?>
 					<th class="<?php echo esc_attr( $level->element_class ); ?>">
-						<h2><?php echo wp_kses( $level->name, pmproal_allowed_html() ); ?></h2>
+					<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_font-large' ) ); ?>"><?php echo wp_kses( $level->name, pmproal_allowed_html() ); ?></h2>
 					</th>
 					<?php
 				}
@@ -197,7 +197,7 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 		<div id="pmpro_level-<?php echo esc_attr( $level->id ); ?>" class="<?php echo esc_attr( $element_class ); ?>">
 			<?php do_action('pmproal_before_level', $level->id, $layout ); ?>
 
-			<h2><?php echo esc_html( $level->name ); ?></h2>
+			<h2><?php echo wp_kses( $level->name, pmproal_allowed_html() ); ?></h2>
 
 			<?php if ( ! empty( $description ) && ! empty( $level->description ) ) { ?>
 				<div class="pmpro_level-description">

--- a/templates/levels-div.php
+++ b/templates/levels-div.php
@@ -26,65 +26,66 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 		$element_class = implode( ' ', array_unique( $element_classes ) );
 		?>
 		<div id="pmpro_level-<?php echo esc_attr( $level->id ); ?>" class="<?php echo esc_attr( $element_class ); ?>">
-			<?php do_action('pmproal_before_level', $level->id, $layout ); ?>
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
+				<?php do_action('pmproal_before_level', $level->id, $layout ); ?>
+				<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) ); ?>"><?php echo wp_kses( $level->name, pmproal_allowed_html() ); ?></h2>
 
-			<h2><?php echo esc_html( $level->name ); ?></h2>
-
-			<?php if ( $layout === 'div' || $layout === '2col' || empty( $layout ) ) { ?>
-				<?php if ( ! empty( $description ) && ! empty( $level->description ) ) { ?>
-					<div class="pmpro_level-description">
-						<?php echo wp_kses_post( wpautop($level->description) ); ?>
-					</div> <!-- end .pmpro_level-description -->
-				<?php } ?>
-
-				<div class="pmpro_level-meta">
-					
-					<?php pmproal_level_button( $level, $checkout_button, $renew_button, $account_button ); ?>
-
-					<?php if ( ! empty( $show_price ) ) { pmproal_getLevelPrice( $level, $price ); } ?>
-
-					<?php if ( ! empty ( $expiration ) ) {
-						$level_expiration = pmpro_getLevelExpiration($level); ?>
-						<p class="pmpro_level-expiration">
-							<?php if ( empty ( $level_expiration ) ) {
-								esc_html_e('Membership never expires.', 'pmpro-advanced-levels-shortcode');
-							} else {
-								echo wp_kses( $level_expiration, pmproal_allowed_html() );
-							} ?>
-						</p> <!-- end pmpro_level-expiration -->
+				<?php if ( $layout === 'div' || $layout === '2col' || empty( $layout ) ) { ?>
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+						<?php if ( ! empty( $description ) && ! empty( $level->description ) ) { ?>
+							<div class="pmpro_level-description">
+								<?php echo wp_kses_post( wpautop($level->description) ); ?>
+							</div> <!-- end .pmpro_level-description -->
+						<?php } ?>
+					</div> <!-- end .pmpro_card_content -->
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">
+						<div class="pmpro_level-meta">
+							<?php pmproal_level_button( $level, $checkout_button, $renew_button, $account_button ); ?>
+							<?php $show_price ? pmproal_getLevelPrice( $level, $price ) : ''; ?>
+							<?php if ( ! empty ( $expiration ) ) {
+								$level_expiration = pmpro_getLevelExpiration($level); ?>
+								<p class="pmpro_level-expiration">
+									<?php if ( empty ( $level_expiration ) ) {
+										esc_html_e('Membership never expires.', 'pmpro-advanced-levels-shortcode');
+									} else {
+										echo wp_kses( $level_expiration, pmproal_allowed_html() );
+									} ?>
+								</p> <!-- end pmpro_level-expiration -->
+							<?php } ?>
+						</div> <!-- .pmpro_level-meta -->
+					</div> <!-- end .pmpro_card_actions -->
+					<?php
+				} else {
+					// This is a column-type div layout
+					?>
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+						<?php $show_price ? pmproal_getLevelPrice( $level, $price ) : ''; ?>
+						<p class="pmpro_level-select">
+							<?php pmproal_level_button( $level, $checkout_button, $renew_button, $account_button ); ?>
+						</p> <!-- end .pmpro_level-select -->
+						<?php if ( ! empty( $description ) && ! empty( $level->description ) ) { ?>
+							<div class="pmpro_level-description">
+								<?php echo wp_kses_post( wpautop($level->description) ); ?>
+							</div> <!-- end .pmpro_level-description -->
+						<?php } ?>
+					</div> <!-- end .pmpro_card_content -->
+					<?php if ( ! empty ( $expiration ) ) { ?>
+						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">
+							<div class="pmpro_level-meta">
+								<?php $level_expiration = pmpro_getLevelExpiration($level); ?>
+								<p class="pmpro_level-expiration">
+									<?php if ( empty ( $level_expiration ) ) {
+										esc_html_e('Membership never expires.', 'pmpro-advanced-levels-shortcode');
+									} else {
+										echo wp_kses( $level_expiration, pmproal_allowed_html() );
+									} ?>
+								</p> <!-- end pmpro_level-expiration -->
+							</div> <!-- .pmpro_level-meta -->
+						</div> <!-- end .pmpro_card_actions -->
 					<?php } ?>
-
-				</div> <!-- .pmpro_level-meta -->
-				<?php 
-			} else {
-				// This is a column-type div layout
-				if ( ! empty( $show_price ) ) { pmproal_getLevelPrice( $level, $price ); } ?>
-					
-				<p class="pmpro_level-select">
-					<?php pmproal_level_button( $level, $checkout_button, $renew_button, $account_button ); ?>
-				</p> <!-- end .pmpro_level-select -->
-
-				<?php if ( ! empty( $description ) && ! empty( $level->description ) ) { ?>
-					<div class="pmpro_level-description">
-						<?php echo wp_kses_post( wpautop($level->description) ); ?>
-					</div> <!-- end .pmpro_level-description -->
 				<?php } ?>
-
-				<?php if ( ! empty ( $expiration ) ) {
-					$level_expiration = pmpro_getLevelExpiration($level); ?>
-					<p class="pmpro_level-expiration">
-						<?php if ( empty ( $level_expiration ) ) {
-							esc_html_e('Membership never expires.', 'pmpro-advanced-levels-shortcode');
-						} else {
-							echo wp_kses( $level_expiration, pmproal_allowed_html() );
-						} ?>
-					</p> <!-- end pmpro_level-expiration -->
-				<?php } ?>
-
-			<?php } ?>
-
-			<?php do_action('pmproal_after_level', $level->id, $layout); ?>
-
+				<?php do_action('pmproal_after_level', $level->id, $layout); ?>
+			</div> <!-- end .pmpro_card -->
 		</div><!-- .pmpro_level -->
 		<?php
 	}

--- a/templates/levels-table.php
+++ b/templates/levels-table.php
@@ -6,72 +6,75 @@
 
 // Build the selectors for the levels wrapper.
 $wrapper_classes = array();
+$wrapper_classes[] = 'pmpro_table';
 $wrapper_classes[] = 'pmpro_advanced_levels-table';
 $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 ?>
-<table id="pmpro_levels" class="<?php echo esc_attr( $wrapper_class ); ?>">
-	<thead>
-		<tr>
-			<?php do_action('pmproal_extra_cols_before_header'); ?>
-			<th><?php esc_html_e('Level', 'pmpro-advanced-levels-shortcode');?></th>
-			<?php if ( ! empty( $show_price ) ) { ?>
-				<th><?php esc_html_e('Price', 'pmpro-advanced-levels-shortcode');?></th>
-			<?php } ?>
-			<?php if ( ! empty( $expiration ) ) { ?>
-				<th><?php esc_html_e('Expiration', 'pmpro-advanced-levels-shortcode');?></th>
-			<?php } ?>
-			<th>&nbsp;</th>
-			<?php do_action('pmproal_extra_cols_after_header'); ?>
-		</tr>
-	</thead>
-	<tbody>
-	<?php
-		foreach( $pmpro_levels_filtered as $level ) {
-			// Build the selectors for the single level elements.
-			$element_classes = array();
-			$element_classes[] = 'pmpro_level';
-			if ( $highlight == $level->id ) {
-				$element_classes[] = 'pmpro_level-highlight';
-			}
-			if ( $level->current_level ) {
-				$element_classes[] = 'pmpro_level-current';
-			}
-			$element_class = implode( ' ', array_unique( $element_classes ) );
-			?>
-			<tr id="pmpro_level-<?php echo esc_attr( $level->id ); ?>" class="<?php echo esc_attr( $element_class ); ?>">
-				<?php do_action('pmproal_extra_cols_before_body', $level->id, $template); ?>
-				<th>
-					<h2><?php echo wp_kses( $level->name, pmproal_allowed_html() ); ?></h2>
-					<?php if ( ! empty( $description ) && ! empty( $level->description ) ) { ?>
-						<div class="pmpro_level-description">
-							<?php echo wp_kses_post( wpautop($level->description) ); ?>
-						</div> <!-- end .pmpro_level-description -->
+<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
+	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+		<table id="pmpro_levels" class="<?php echo esc_attr( pmpro_get_element_class( $wrapper_class ) ); ?>">
+			<thead>
+				<tr>
+					<?php do_action('pmproal_extra_cols_before_header'); ?>
+					<th><?php esc_html_e('Level', 'pmpro-advanced-levels-shortcode');?></th>
+					<?php if ( ! empty( $show_price ) ) { ?>
+						<th><?php esc_html_e('Price', 'pmpro-advanced-levels-shortcode');?></th>
 					<?php } ?>
-				</th>
-				<?php if ( ! empty( $show_price ) ) { ?>
-					<td>
-						<?php pmproal_getLevelPrice( $level, $price ); ?>
-					</td>
-				<?php } ?>
-
-				<?php if ( ! empty ( $expiration ) ) {
-					$level_expiration = pmpro_getLevelExpiration($level); ?>
-					<td class="pmpro_level-expiration">
-						<?php if ( empty ( $level_expiration ) ) {
-							esc_html_e('Membership never expires.', 'pmpro-advanced-levels-shortcode');
-						} else {
-							echo wp_kses( $level_expiration, pmproal_allowed_html() );
-						} ?>
-					</td>
-				<?php } ?>
-
-				<td>
-					<?php pmproal_level_button( $level, $checkout_button, $renew_button, $account_button ); ?>
-				</td>
-				<?php do_action('pmproal_extra_cols_after_body', $level->id, $template); ?>
-			</tr>
-		<?php
-		}
-	?>
-	</tbody>
-</table>
+					<?php if ( ! empty( $expiration ) ) { ?>
+						<th><?php esc_html_e('Expiration', 'pmpro-advanced-levels-shortcode');?></th>
+					<?php } ?>
+					<th>&nbsp;</th>
+					<?php do_action('pmproal_extra_cols_after_header'); ?>
+				</tr>
+			</thead>
+			<tbody>
+			<?php
+				foreach( $pmpro_levels_filtered as $level ) {
+					// Build the selectors for the single level elements.
+					$element_classes = array();
+					$element_classes[] = 'pmpro_level';
+					if ( $highlight == $level->id ) {
+						$element_classes[] = 'pmpro_level-highlight';
+					}
+					if ( $level->current_level ) {
+						$element_classes[] = 'pmpro_level-current';
+					}
+					$element_class = implode( ' ', array_unique( $element_classes ) );
+					?>
+					<tr id="pmpro_level-<?php echo esc_attr( $level->id ); ?>" class="<?php echo esc_attr( $element_class ); ?>">
+						<?php do_action('pmproal_extra_cols_before_body', $level->id, $template); ?>
+						<th>
+							<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_font-large' ) ); ?>"><?php echo wp_kses( $level->name, pmproal_allowed_html() ); ?></h2>
+							<?php if ( ! empty( $description ) && ! empty( $level->description ) ) { ?>
+								<div class="pmpro_level-description">
+									<?php echo wp_kses_post( wpautop($level->description) ); ?>
+								</div> <!-- end .pmpro_level-description -->
+							<?php } ?>
+						</th>
+						<?php if ( ! empty( $show_price ) ) { ?>
+							<td>
+								<?php pmproal_getLevelPrice( $level, $price ); ?>
+							</td>
+						<?php } ?>
+						<?php if ( ! empty ( $expiration ) ) {
+							$level_expiration = pmpro_getLevelExpiration($level); ?>
+							<td class="pmpro_level-expiration">
+								<?php if ( empty ( $level_expiration ) ) {
+									esc_html_e('Membership never expires.', 'pmpro-advanced-levels-shortcode');
+								} else {
+									echo wp_kses( $level_expiration, pmproal_allowed_html() );
+								} ?>
+							</td>
+						<?php } ?>
+						<td>
+							<?php pmproal_level_button( $level, $checkout_button, $renew_button, $account_button ); ?>
+						</td>
+						<?php do_action('pmproal_extra_cols_after_body', $level->id, $template); ?>
+					</tr>
+				<?php
+				}
+			?>
+			</tbody>
+		</table>
+	</div> <!-- end .pmpro_card_content -->
+</div> <!-- end .pmpro_card -->

--- a/templates/levels.php
+++ b/templates/levels.php
@@ -160,6 +160,11 @@ function pmpro_advanced_levels_shortcode($atts, $content=null, $code="") {
 		$level->current_level = pmpro_hasMembershipLevel( $level->id );
 	}
 
+	// Open the wrapping div for the levels.
+	?>
+	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
+	<?php
+
 	// Show the pmpro_msg variable.
 	if ( $pmpro_msg ) { ?>
 		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>"><?php echo wp_kses_post( $pmpro_msg ); ?></div>
@@ -190,6 +195,8 @@ function pmpro_advanced_levels_shortcode($atts, $content=null, $code="") {
 			</span>
 		</div>
 	<?php } ?>
+
+	</div><!--.pmpro-->
 
 	<?php
 	$temp_content = ob_get_contents();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This is so fun! Styles updated for v3.1.

Before (pre 3.1 versions)
![Screenshot 2024-07-12 at 10 04 05 AM](https://github.com/user-attachments/assets/803a1a9f-9005-4840-b744-b0e1682582a5)

With v3.1+
![Screenshot 2024-07-12 at 10 03 12 AM](https://github.com/user-attachments/assets/8dc429fa-4f30-4f34-9a2d-ebb74a7f38ce)
