### PR TITLE
Accessibility improvements to the checkout links and empty header row

### DIFF
--- a/pmpro-advanced-levels-shortcode.php
+++ b/pmpro-advanced-levels-shortcode.php
@@ -164,6 +164,7 @@ function pmproal_level_button( $level, $checkout_button, $renew_button, $account
 		$button_classes[] = 'pmpro_btn-select';
 		$button_link = add_query_arg( $level->link_arguments, pmpro_url( 'checkout', '', 'https' ) );
 		$button_text = $checkout_button;
+		$button_aria_label = sprintf( __( 'Select the %s membership level', 'pmpro-advanced-levels-shortcode' ), $level->name );
 	} elseif( $level->current_level ) {
 		// Get specific level details for the user
 		$specific_level = pmpro_getSpecificMembershipLevelForUser( $current_user->ID, $level->id );
@@ -173,17 +174,19 @@ function pmproal_level_button( $level, $checkout_button, $renew_button, $account
 			$button_classes[] = 'pmpro_btn-renew';
 			$button_link = add_query_arg( $level->link_arguments, pmpro_url( 'checkout', '', 'https' ) );
 			$button_text = $renew_button;
+			$button_aria_label = sprintf( __( 'Renew the %s membership level', 'pmpro-advanced-levels-shortcode' ), $level->name );
 		} else {
 			// Show account button otherwise
 			$button_classes[] = 'disabled';
 			$button_link = pmpro_url( 'account' );
 			$button_text = $account_button;
+			$button_aria_label = sprintf( __( 'Manage your %s membership', 'pmpro-advanced-levels-shortcode' ), $level->name );
 		}
 	}
 
 	// Output the button.
 	?>
-	<a aria-label="<?php echo esc_attr( sprintf( __('Select the %s membership level', 'pmpro-advanced-levels-shortcode' ), $level->name ) ); ?>" class="<?php echo esc_attr( implode( ' ', array_unique( $button_classes ) ) ); ?>" href="<?php echo esc_url( $button_link ); ?>"><?php echo esc_html( $button_text ); ?></a>
+	<a aria-label="<?php echo esc_attr( $button_aria_label ); ?>" class="<?php echo esc_attr( implode( ' ', array_unique( $button_classes ) ) ); ?>" href="<?php echo esc_url( $button_link ); ?>"><?php echo esc_html( $button_text ); ?></a>
 	<?php
 }
 

--- a/pmpro-advanced-levels-shortcode.php
+++ b/pmpro-advanced-levels-shortcode.php
@@ -183,7 +183,7 @@ function pmproal_level_button( $level, $checkout_button, $renew_button, $account
 
 	// Output the button.
 	?>
-	<a class="<?php echo esc_attr( implode( ' ', array_unique( $button_classes ) ) ); ?>" href="<?php echo esc_url( $button_link ); ?>"><?php echo esc_html( $button_text ); ?></a>
+	<a aria-label="<?php echo esc_attr( sprintf( __('Select the %s membership level', 'pmpro-advanced-levels-shortcode' ), $level->name ) ); ?>" class="<?php echo esc_attr( implode( ' ', array_unique( $button_classes ) ) ); ?>" href="<?php echo esc_url( $button_link ); ?>"><?php echo esc_html( $button_text ); ?></a>
 	<?php
 }
 

--- a/templates/levels-table.php
+++ b/templates/levels-table.php
@@ -23,7 +23,7 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 					<?php if ( ! empty( $expiration ) ) { ?>
 						<th><?php esc_html_e('Expiration', 'pmpro-advanced-levels-shortcode');?></th>
 					<?php } ?>
-					<th>&nbsp;</th>
+					<th><span class="screen-reader-text"><?php esc_html_e( 'Action', 'pmpro-advanced-levels-shortcode' ); ?></span></th>
 					<?php do_action('pmproal_extra_cols_after_header'); ?>
 				</tr>
 			</thead>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updated the links to checkout to include a more descriptive link aria-label like core PMPro.

Added screen reader text to empty header cell.

### Changelog entry
* ENHANCEMENT: Improved accessibility of levels page buttons that link to checkout.
* ENHANCEMENT: Improved accessibility of table layout levels page. 

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
