### PR TITLE
Fix compare table warnings and layout

### DIFF
--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -223,20 +223,15 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 					 */
 					$compareitem_values = apply_filters( 'pmpro_advanced_levels_compare_items', $compareitem_values );
 
-					if ( $count >= 0 && ! empty( $numeric_levels_array[$count] ) ) {
-						$compare_level = $numeric_levels_array[$count];
+					echo '<li><strong>' . wp_kses( $compareitem_values[0], pmproal_allowed_html() ) . '</strong>: ';
+					if ( empty( $compareitem_values[ $count ] ) ) {
+						echo esc_html__( 'No', 'pmpro-advanced-levels-shortcode' );
+					} elseif ( '1' === $compareitem_values[ $count ] ) {
+						echo esc_html__( 'Yes', 'pmpro-advanced-levels-shortcode' );
 					} else {
-						$compare_level = NULL;
+						echo wp_kses( $compareitem_values[ $count ], pmproal_allowed_html() ) . '</li>';
 					}
-
-					if ( $compareitem_values[$count] != '0' ) { 
-						if ( $compareitem_values[$count] == '1' ) {
-							echo '<li><strong>' . wp_kses( $compareitem_values[0], pmproal_allowed_html() ) . '</strong></li>';
-						} else {
-							echo '<li><strong>' . wp_kses( $compareitem_values[0], pmproal_allowed_html() ) . '</strong>: ';
-							echo wp_kses( $compareitem_values[$count], pmproal_allowed_html() ) . '</li>';
-						}
-					}
+					echo '</li>';
 				}
 				echo '</ul>';
 			} ?>

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -105,10 +105,12 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 					$compareitem_values = apply_filters( 'pmpro_advanced_levels_compare_items', $compareitem_values );
 
 					foreach ( $compareitem_values as $compareitem_value ) {
-						if ( $count >= 0 && ! empty( $numeric_levels_array[$count] ) ) {
-							$level = $numeric_levels_array[$count];
+						if ( $count < 0 ) {
+							$level = null;
+						} elseif ( empty( $numeric_levels_array[ $count ] ) ) {
+							break;
 						} else {
-							$level = NULL;
+							$level = $numeric_levels_array[ $count ];
 						}
 						$count++;
 						?>

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -223,15 +223,13 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 					 */
 					$compareitem_values = apply_filters( 'pmpro_advanced_levels_compare_items', $compareitem_values );
 
-					echo '<li><strong>' . wp_kses( $compareitem_values[0], pmproal_allowed_html() ) . '</strong>: ';
-					if ( empty( $compareitem_values[ $count ] ) ) {
-						echo esc_html__( 'No', 'pmpro-advanced-levels-shortcode' );
-					} elseif ( '1' === $compareitem_values[ $count ] ) {
-						echo esc_html__( 'Yes', 'pmpro-advanced-levels-shortcode' );
-					} else {
-						echo wp_kses( $compareitem_values[ $count ], pmproal_allowed_html() );
+					if ( ! empty( $compareitem_values[ $count ] ) && '0' !== $compareitem_values[ $count ] ) {
+						echo '<li><strong>' . wp_kses( $compareitem_values[0], pmproal_allowed_html() ) . '</strong>';
+						if ( '1' !== $compareitem_values[ $count ] ) {
+							echo ': ' . wp_kses( $compareitem_values[ $count ], pmproal_allowed_html() );
+						}
+						echo '</li>';
 					}
-					echo '</li>';
 				}
 				echo '</ul>';
 			} ?>

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -229,7 +229,7 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 					} elseif ( '1' === $compareitem_values[ $count ] ) {
 						echo esc_html__( 'Yes', 'pmpro-advanced-levels-shortcode' );
 					} else {
-						echo wp_kses( $compareitem_values[ $count ], pmproal_allowed_html() ) . '</li>';
+						echo wp_kses( $compareitem_values[ $count ], pmproal_allowed_html() );
 					}
 					echo '</li>';
 				}

--- a/templates/levels-compare_table.php
+++ b/templates/levels-compare_table.php
@@ -221,7 +221,6 @@ $wrapper_class = implode( ' ', array_unique( $wrapper_classes ) );
 					 */
 					$compareitem_values = apply_filters( 'pmpro_advanced_levels_compare_items', $compareitem_values );
 
-					$compareitem_values = explode( ',', $compareitem );
 					if ( $count >= 0 && ! empty( $numeric_levels_array[$count] ) ) {
 						$compare_level = $numeric_levels_array[$count];
 					} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-advanced-levels-page-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Prevents "Undefined array key" warnings from the compare table small screen layout if compare items count exceeds visible level count. Resolves #78 .

Stops values filtered by `pmpro_advanced_levels_compare_items` being overriden for the compare table small screen layout.

Prevents the addition of unnecessary columns when using the compare table layout, if the number of compare items provided exceeds the number of visible levels.
Example before:
![compare-table-big-before-invalid-compare](https://github.com/user-attachments/assets/7a4c1805-eb60-461a-92d1-689e5afe2485)
After:
![compare-table-big-after-invalid-compare](https://github.com/user-attachments/assets/9428b609-51ae-4995-be0c-b532d084eeef)

Ensure correct compare item values are displayed for each level on the compare table for small screens. ~~Also displaying _Yes_ or _No_ instead of blanks for 0 and 1 compare item values on this layout.~~ Now hiding, blank compare items on this layout.
Example before:
![compare-table-small-before-invalid-compare](https://github.com/user-attachments/assets/851532c3-80f2-40d3-ba71-3554f420d660)
After:
<img width="398" height="956" alt="image" src="https://github.com/user-attachments/assets/6cdb795a-632b-418a-bb9e-d27f19b7cd5b" />

Test shortcode used for screenshots above: `[pmpro_advanced_levels levels="1,2" layout="compare_table" compare="Feature 1,1;Feature 2;Feature 3,1,1;Feature 4,1,1,1,1,1;Feature 5,a,b,c,d;Feature 6,1,1,1"]`


### How to test the changes in this Pull Request:
1. Add an Advanced Levels Shortcode to a page, and set the layout to _compare_table_.
2. Add some comparison rows via the _compare_ attribute. Include more or less items than the level count for some rows.
3. Visit the advanced levels page.
4. Observe table appearance and check debug log for warnings.
5. Apply PR.
6. Refresh the advanced levels page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
